### PR TITLE
Allow additional s3 options

### DIFF
--- a/.nvmignore
+++ b/.nvmignore
@@ -1,0 +1,5 @@
+test
+coverage
+.coveralls.yml
+.travis.yml
+.eslint*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '4'
+  - '6'
 script: npm run lint && npm t
 before_install:
   - npm i -g npm@^2.0.0

--- a/README.md
+++ b/README.md
@@ -15,9 +15,24 @@ compressed and uploaded to s3.
 ```javascript
 const sb = require('serverless-builder');
 const dependencies = require('./package.json').dependencies;
-sb(dependencies, { Bucket: 'my-s3-bucket' })
+sb(dependencies, { Bucket: 'my-s3-bucket' }, { Region: 'us-east-1' })
   .then(res => {
     // res contains the s3 key and bucket that the node_modules tgz was uploaded
     // to.
   });
 ```
+
+## API
+
+* `serverless-builder` - Accepts a list of packages and s3 configuration options
+  and returns a promise that resolves with the location in s3 that the package
+  was saved to.
+ * `packages` - An object of npm packages to install, keyed by package name,
+   with the package version or install path as the value. This object takes the
+   same format as the `dependencies` object in `package.json` files.
+ * s3ObjectOptions - Options to pass to the S3 write stream. This object
+   _must_ contain at least `Bucket` and may contain any other valid S3 putObject
+   options.
+ * s3Options - (optional) Options to pass to the S3 instance. This object may
+   contain any options used when instantiating a S3 object.
+

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ temp.track();
  *   Resolves when the install finishes, else rejects.
  */
 module.exports = (packages, s3ObjectOptions, s3Options) => new Promise((resolve, reject) => {
-  s3Options = s3Options || {};
+  const myS3Options = s3Options || {};
   temp.mkdir('builder', (err, path) => {
     if (err) {
       return reject(err);
@@ -53,7 +53,7 @@ module.exports = (packages, s3ObjectOptions, s3Options) => new Promise((resolve,
             const Key = `${path.split('/').pop()}.tgz`;
             tar.pack(`${path}/node_modules`)
               .pipe(zlib.Gzip())
-              .pipe(WriteStream(new S3(s3Options), Object.assign({ Key }, s3ObjectOptions)))
+              .pipe(WriteStream(new S3(myS3Options), Object.assign({ Key }, s3ObjectOptions)))
               .on('finish', () => {
                 resolve({
                   Bucket: s3ObjectOptions.Bucket,

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const npm = require('npm');
 const tar = require('tar-fs');
 const temp = require('temp');
 const zlib = require('zlib');
-const S3 = require('aws-sdk').S3;
-const S3S = require('s3-streams');
+const { S3 } = require('aws-sdk');
+const { WriteStream } = require('s3-streams');
 
 temp.track();
 
@@ -16,13 +16,15 @@ temp.track();
  * @param {Object} packages
  *  An object of npm packages to install, keyed by package name, with the
  *  package version or install path as the value.
+ * @param {Object} s3ObjectOptions
+ *   Options to pass to the S3 write stream.
  * @param {Object} s3Options
- *   Options to pass to s3-streams.
+ *   Options to pass to the S3 instance.
  *
  * @return {Promise}
  *   Resolves when the install finishes, else rejects.
  */
-module.exports = (packages, s3Options) => new Promise((resolve, reject) => {
+module.exports = (packages, s3ObjectOptions, s3Options = {}) => new Promise((resolve, reject) => {
   temp.mkdir('builder', (err, path) => {
     if (err) {
       return reject(err);
@@ -50,10 +52,10 @@ module.exports = (packages, s3Options) => new Promise((resolve, reject) => {
             const Key = `${path.split('/').pop()}.tgz`;
             tar.pack(`${path}/node_modules`)
               .pipe(zlib.Gzip())
-              .pipe(S3S.WriteStream(new S3(), Object.assign({ Key }, s3Options)))
+              .pipe(WriteStream(new S3(s3Options), Object.assign({ Key }, s3ObjectOptions)))
               .on('finish', () => {
                 resolve({
-                  Bucket: s3Options.Bucket,
+                  Bucket: s3ObjectOptions.Bucket,
                   Key,
                 });
               })

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const npm = require('npm');
 const tar = require('tar-fs');
 const temp = require('temp');
 const zlib = require('zlib');
-const { S3 } = require('aws-sdk');
-const { WriteStream } = require('s3-streams');
+const S3 = require('aws-sdk').S3;
+const WriteStream = require('s3-streams').WriteStream;
 
 temp.track();
 
@@ -24,7 +24,8 @@ temp.track();
  * @return {Promise}
  *   Resolves when the install finishes, else rejects.
  */
-module.exports = (packages, s3ObjectOptions, s3Options = {}) => new Promise((resolve, reject) => {
+module.exports = (packages, s3ObjectOptions, s3Options) => new Promise((resolve, reject) => {
+  s3Options = s3Options || {};
   temp.mkdir('builder', (err, path) => {
     if (err) {
       return reject(err);

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "url": "https://github.com/elliotttf/serverless-builder.git"
   },
   "config": {
-    "pre-commit": "npm run lint"
+    "ghooks": {
+      "pre-commit": "npm run lint"
+    }
   }
 }


### PR DESCRIPTION
serverless-builder will now accept options both for the object that is being sent to s3 as well as the s3 instance itself.